### PR TITLE
Fixed for new version of Spotify 5-29-2015

### DIFF
--- a/src/spotify.c
+++ b/src/spotify.c
@@ -32,7 +32,7 @@ static int spotify_cb(char *word[], char *word_eol[], void *userdata)
 				GetWindowText(hWnd, title, title_length);
 				if(strcmp(title, "Spotify") != 0)
 				{
-					hexchat_commandf(ph, "me is now listening to: %s", title + (10 * sizeof *title));
+					hexchat_commandf(ph, "me is now listening to: %s", title);
 				}
 				else
 				{


### PR DESCRIPTION
Removed ' + (10 \* sizeof *title)' which allows it to work on the latest version of Spotify for Windows.

[18:39:43] »» @Seth is now listening to: 3OH!3 - Touchin On My
